### PR TITLE
[Fixed #77] 작은 화면에서도 오류 페이지 잘 나오도록 수정

### DIFF
--- a/view/error/exception.twig
+++ b/view/error/exception.twig
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, user-scalable=no" />
     <title>Oops!</title>
 </head>
 <style>

--- a/view/error/exception.twig
+++ b/view/error/exception.twig
@@ -6,6 +6,9 @@
     <title>Oops!</title>
 </head>
 <style>
+    h1 {
+        display: none;
+    }
     div.error {
         margin: 100px 200px;
         border: 1px solid rgb(220, 220, 220);
@@ -13,11 +16,12 @@
     }
 
     div.error p {
-        margin: 0;
-        padding: 15px;
+        margin: 15px;
     }
 
-    p.message {
+    h2.message {
+        margin: 0;
+        padding: 15px;
         font-size: 18pt;
         font-weight: bold;
         border-radius: 10px;
@@ -109,8 +113,9 @@
 </style>
 <body>
 
+<h1>Error raised!</h1>
 <div class="error">
-    <p class="message">{{ message }}</p>
+    <h2 class="message">{{ message }}</h2>
 
     {% if displayExceptionInfo == true %}
         <p class="errorName">Exception: {{ errorName }}</p>

--- a/view/error/exception.twig
+++ b/view/error/exception.twig
@@ -47,7 +47,7 @@
     }
     table.code th, table.code td {
         padding: 3px 0.75em;
-        white-space: pre;
+        white-space: pre-wrap;
     }
 
     div.trace {
@@ -91,6 +91,16 @@
     }
     span.function {
         font-weight: bold;
+    }
+
+    @media (max-width: 1024px) {
+        div.error {
+            margin: 20px;
+        }
+
+        div.error p {
+            overflow: auto;
+        }
     }
 </style>
 <body>

--- a/view/error/exception.twig
+++ b/view/error/exception.twig
@@ -31,8 +31,12 @@
         padding-bottom: 0px;
     }
 
-    table.code {
+    div.code-wrap {
         margin: 0 40px;
+        overflow: auto;
+    }
+
+    table.code {
         border-collapse: collapse;
     }
     table.code tr.active {
@@ -118,6 +122,7 @@
 
     {% if displayErrorSourceLines == true %}
         <p><strong>Code</strong></p>
+        <div class="code-wrap">
         <table class="code">
         {% for codeLine, code in errorSourceLines %}
             <tr class="{{ line == codeLine + 1 ? 'active' : '' }}">
@@ -126,6 +131,7 @@
             </tr>
         {% endfor %}
         </table>
+        </div>
     {% endif %}
 
     {% if displayStackTrace == true %}


### PR DESCRIPTION
수정사항
- viewport 관련 추가 (모바일-저해상도-에서 꽉차도록 만듬)
- 저해상도 일때 전체적인 margin 수정
- ```overflow:auto```, ```white-space: pre-wrap``` 로 주어 오류메시지가 툭 튀어나오는 문제 수정
- 오류 메시지 등을 h1, h2 태그 등의 의미있는 태그를 사용하도록 함

| 구분 | 스크린샷 |
|------|-----------|
| 기존 | ![image](https://cloud.githubusercontent.com/assets/15353893/21750079/8e4d33bc-d5ee-11e6-9c3d-434f4672e16b.png) |
| 현재 | ![image](https://cloud.githubusercontent.com/assets/15353893/21750089/a94e6f14-d5ee-11e6-9da0-2d70d3c46bbe.png) |